### PR TITLE
Uppercased the codes.

### DIFF
--- a/common-error-codes.js
+++ b/common-error-codes.js
@@ -1,17 +1,17 @@
 var registry = require('./error-code-registry');
 
 var codes = {
-	access_denied: { message: 'Access Denied', http: 403 },
-	already_exists: { message: 'Already Exists', http: 409 },
-	bad_request: { message: 'Bad Request', http: 400 },
-	internal_error: { message: 'Internal Error', http: 500 },
-	not_found: { message: 'Not Found', http: 404 },
-	unsupported_format: { message: 'Unsupported format', http: 415 },
-	timed_out: { message: 'Operation timed out', http: 504 },
-	unsupported_operation: { message: 'Operation not supported', http: 404 },
-	limit_exceeded: { message: 'Limit exceeded', http: 503 },
-	not_modified: { message: 'Not modified', http: 304 },
-	invalid_argument: { message: 'Invalid data passed to function', http: 401 }
+	ACCESS_DENIED: { message: 'Access Denied', http: 403 },
+	ALREADY_EXISTS: { message: 'Already Exists', http: 409 },
+	BAD_REQUEST: { message: 'Bad Request', http: 400 },
+	INTERNAL_ERROR: { message: 'Internal Error', http: 500 },
+	NOT_FOUND: { message: 'Not Found', http: 404 },
+	UNSUPPORTED_FORMAT: { message: 'Unsupported format', http: 415 },
+	TIMED_OUT: { message: 'Operation timed out', http: 504 },
+	UNSUPPORTED_OPERATION: { message: 'Operation not supported', http: 404 },
+	LIMIT_EXCEEDED: { message: 'Limit exceeded', http: 503 },
+	NOT_MODIFIED: { message: 'Not modified', http: 304 },
+	INVALID_ARGUMENT: { message: 'Invalid data passed to function', http: 401 }
 };
 
 module.exports = function() {

--- a/docs/files/error-code-registry.js.html
+++ b/docs/files/error-code-registry.js.html
@@ -136,7 +136,7 @@ exports.registerErrorCode = function(code, fields, version) {
 	}
 	registry.codes[code].code = code;
 	registry.xerrors.forEach(function(XError) {
-		XError[code.toUpperCase()] = code;
+		XError[code] = code;
 	});
 };
 

--- a/docs/files/xerror.js.html
+++ b/docs/files/xerror.js.html
@@ -162,7 +162,7 @@ XError.prototype = Object.create(Error.prototype, {
 
 // Register code accessors on the error object
 registry.listErrorCodes().forEach(function(code) {
-	XError[code.toUpperCase()] = code;
+	XError[code] = code;
 });
 registry.addXError(XError);
 

--- a/error-code-registry.js
+++ b/error-code-registry.js
@@ -54,7 +54,7 @@ exports.registerErrorCode = function(code, fields, version) {
 	}
 	registry.codes[code].code = code;
 	registry.xerrors.forEach(function(XError) {
-		XError[code.toUpperCase()] = code;
+		XError[code] = code;
 	});
 };
 

--- a/xerror.js
+++ b/xerror.js
@@ -80,7 +80,7 @@ XError.prototype = Object.create(Error.prototype, {
 
 // Register code accessors on the error object
 registry.listErrorCodes().forEach(function(code) {
-	XError[code.toUpperCase()] = code;
+	XError[code] = code;
 });
 registry.addXError(XError);
 


### PR DESCRIPTION
I see no reason to convert cases.  It is common to define such code registries in all uppercase from the beginning, and do no case conversion.

This clears up the confusion of registering `foo_bar`, but referring to it afterward as `XError.FOO_BAR`.
